### PR TITLE
Throw an error when server status code is not 2

### DIFF
--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -814,6 +814,11 @@ function Client() {
 
                 if (typeof self.responseCallback == 'function') self.responseCallback(responseEnvelope);
 
+                if (responseEnvelope.status_code !== 2) {
+                    reject(Error('Status code ' + responseEnvelope.status_code + ' received from RPC'));
+                    return;
+                }
+
                 if (responseEnvelope.error) {
                     reject(Error(responseEnvelope.error));
                     return;


### PR DESCRIPTION
Looks like github removed the end of file newline on its own, can look into that if its a problem.
