### PR TITLE
Fix for err in rejects from GoogleLogin promises being empty object

### DIFF
--- a/pogobuf/pogobuf.googlelogin.js
+++ b/pogobuf/pogobuf.googlelogin.js
@@ -45,7 +45,7 @@ function GoogleLogin() {
         return new Promise((resolve, reject) => {
             google.login(username, password, GOOGLE_LOGIN_ANDROID_ID, (err, data) => {
                 if (err) {
-                    reject(err.response.statusCode + ': ' + err.response.statusMessage);
+                    reject(Error(err.response.statusCode + ': ' + err.response.statusMessage));
                     return;
                 }
 
@@ -65,7 +65,7 @@ function GoogleLogin() {
         return new Promise((resolve, reject) => {
             google.oauth(username, loginData.masterToken, loginData.androidId, GOOGLE_LOGIN_SERVICE, GOOGLE_LOGIN_APP, GOOGLE_LOGIN_CLIENT_SIG, (err, data) => {
                 if (err) {
-                    reject(err.response.statusCode + ': ' + err.response.statusMessage);
+                    reject(Error(err.response.statusCode + ': ' + err.response.statusMessage));
                     return;
                 }
 

--- a/pogobuf/pogobuf.googlelogin.js
+++ b/pogobuf/pogobuf.googlelogin.js
@@ -45,7 +45,7 @@ function GoogleLogin() {
         return new Promise((resolve, reject) => {
             google.login(username, password, GOOGLE_LOGIN_ANDROID_ID, (err, data) => {
                 if (err) {
-                    reject(Error(err));
+                    reject(err.response.statusCode + ': ' + err.response.statusMessage);
                     return;
                 }
 
@@ -65,7 +65,7 @@ function GoogleLogin() {
         return new Promise((resolve, reject) => {
             google.oauth(username, loginData.masterToken, loginData.androidId, GOOGLE_LOGIN_SERVICE, GOOGLE_LOGIN_APP, GOOGLE_LOGIN_CLIENT_SIG, (err, data) => {
                 if (err) {
-                    reject(Error(err));
+                    reject(err.response.statusCode + ': ' + err.response.statusMessage);
                     return;
                 }
 


### PR DESCRIPTION
I noticed that when a Promise rejects from a GoogleLogin method, the err returned in the reject is just an empty object. For example: 

`login.login(username, password).then(token => {
        //do stuff with token
    }, err => {
        console.log(err)
               //err prints as '{}'
});`

Changing the Promises to reject with the statusCode and statusMessage of the response at least gives  a (reasonably) meaningful error.

I'm not sure if the same thing happens with PTCLogin methods or not. I have not tried them.
