### PR TITLE
Wrong init

### DIFF
--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -71,9 +71,9 @@ function Client() {
         return self.batchStart()
             .getPlayer()
             .getHatchedEggs()
-            .getInventory(0)
+            .getInventory()
             .checkAwardedBadges()
-            .downloadSettings('05daf51635c82611d1aac95c0b051d3ec088a930')
+            .downloadSettings()
             .batchCall();
     };
 


### PR DESCRIPTION
The current INIT throws in the hash for you, while the hash could change (has changed). 

The first request for inventory in the app sends no data at all, no 0 too. So we shouldn't do so.

The first request doesn't send a hash too. The server will respond with the settings, after that the hash given should be used with every other request. 

If we pass the hash into the INIT it doesn't look real but besides that we'll never get the settings JSON;

```
{ error: '',
  hash: '80f4f3719421640d132515f1c293fe0455ae8d53',
  settings: 
   { fort_settings: 
      { interaction_range_meters: 40,
        max_total_deployed_pokemon: 10,
        max_player_deployed_pokemon: 1,
        deploy_stamina_multiplier: 2,
        deploy_attack_multiplier: 0,
        far_interaction_range_meters: 1000 },
     map_settings: 
      { pokemon_visible_range: 70,
        poke_nav_range_meters: 201,
        encounter_range_meters: 50,
        get_map_objects_min_refresh_seconds: 5,
        get_map_objects_max_refresh_seconds: 30,
        get_map_objects_min_distance_meters: 10,
        google_maps_api_key: 'IzaSyDFrkP8lhcddBtvH9gVFzjnNo13WtmJI' },
     level_settings: null,
     inventory_settings: 
      { max_pokemon: 1000,
        max_bag_items: 1000,
        base_pokemon: 250,
        base_bag_items: 350,
        base_eggs: 9 },
     minimum_client_version: '0.29.0' } }
```

Something I do want, because it provides us with the fort interaction range and map refresh rate.
