### PR TITLE
Fix cellids

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,14 @@ auth token.
 | password | <code>string</code> |
 
 ## `pogobuf.Utils` methods
+### `getCellIDs(lat, lng)` ⇒ <code>array</code> *(static)*
+Provides cell IDs of nearby cells based on the given coords.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| lat | <code>number</code> | Latitude |
+| lng | <code>number</code> | Longitude |
+
 ### `splitInventory(inventory)` ⇒ <code>object</code> *(static)*
 Takes a `getInventory()` response and separates it into pokemon, items, candies, player
 data, eggs, and pokedex.

--- a/examples/gym-details.js
+++ b/examples/gym-details.js
@@ -16,7 +16,6 @@
 
 const pogobuf = require('pogobuf'),
     POGOProtos = require('node-pogo-protos'),
-    S2 = require('s2-geometry').S2,
     nodeGeocoder = require('node-geocoder');
 
 var login = new pogobuf.PTCLogin(),
@@ -52,7 +51,7 @@ geocoder.geocode('2 Bryant St, San Francisco')
     })
     .then(() => {
         // Retrieve all map objects in the surrounding area
-        var cellIDs = getCellIDs(lat, lng);
+        var cellIDs = pogobuf.Utils.getCellIDs(lat, lng);
         return client.getMapObjects(cellIDs, Array(cellIDs.length).fill(0));
     })
     .then(mapObjects => {
@@ -92,39 +91,3 @@ geocoder.geocode('2 Bryant St, San Francisco')
         });
     })
     .catch(console.error);
-
-/**
- * Utility method to get all the S2 Cell IDs in a given radius.
- * @param {number} lat
- * @param {number} lng
- * @returns {array} Array of cell Ids
- */
-function getCellIDs(lat, lng) {
-    var origin = S2.S2Cell.FromLatLng({ lat: lat, lng: lng }, 15);
-    var cells = [];
-
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 1], origin.level).toHilbertQuadkey());
-    cells.push(origin.toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1]], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1]], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1]], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 2], origin.level).toHilbertQuadkey());
-    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
-
-    return cells.map((cell) => {
-        return S2.toId(cell);
-    });
-}

--- a/examples/gym-details.js
+++ b/examples/gym-details.js
@@ -16,7 +16,7 @@
 
 const pogobuf = require('pogobuf'),
     POGOProtos = require('node-pogo-protos'),
-    s2 = require('s2geometry-node'),
+    S2 = require('s2-geometry').S2,
     nodeGeocoder = require('node-geocoder');
 
 var login = new pogobuf.PTCLogin(),
@@ -100,28 +100,31 @@ geocoder.geocode('2 Bryant St, San Francisco')
  * @returns {array} Array of cell Ids
  */
 function getCellIDs(lat, lng) {
-    var origin = new s2.S2CellId(new s2.S2LatLng(lat, lng)).parent(15);
-    var cells = [origin.prev()];
+    var origin = S2.S2Cell.FromLatLng({ lat: lat, lng: lng }, 15);
+    var cells = [];
 
-    // Find previous cells based on latest
-    var previousCell = cells[0];
-    for (var i = 0; i < 7; i++) {
-        previousCell = previousCell.prev();
-        cells.unshift(previousCell);
-    }
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+    cells.push(origin.toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1]], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1]], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1]], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+    cells.push(S2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
 
-     // Find next cells based on latest
-    var nextCell = cells[cells.length - 1];
-    for (var i = 0; i < 24; i++) {
-        nextCell = nextCell.next();
-
-        // Skip some to build perfect shape
-        if (i < 10 || i > 21) {
-            cells.push(nextCell);
-        }
-    }
-
-    return cells.map(cell => {
-        return cell.id();
+    return cells.map((cell) => {
+        return S2.toId(cell);
     });
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "gpsoauthnode": "0.0.5",
     "long": "^3.2.0",
     "node-pogo-protos": "^1.1.0",
-    "request": "^2.73.0"
+    "request": "^2.73.0",
+    "s2-geometry": "^1.2.4"
   },
   "devDependencies": {
     "eslint": "^3.1.1",

--- a/pogobuf/pogobuf.utils.js
+++ b/pogobuf/pogobuf.utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var s2 = require('s2-geometry').S2;
+
 /**
  * Various utilities for dealing with Pokémon Go API requests.
  * @class Utils
@@ -7,6 +9,43 @@
  */
 
 module.exports = {
+    /**
+     * Provides cell IDs of nearby cells based on the given lat lang
+     * @param {number} lat
+     * @param {number} lng
+     * @returns {array}
+     * @static
+     */
+    getCellIDs: function(lat, lng) {
+        var origin = s2.S2Cell.FromLatLng({ lat: lat, lng: lng }, 15);
+        var cells = [];
+
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] - 1], origin.level).toHilbertQuadkey());
+        cells.push(origin.toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1]], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1]], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1]], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 1], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 2, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] - 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0], origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+        cells.push(s2.S2Cell.FromFaceIJ(origin.face, [origin.ij[0] + 1, origin.ij[1] + 2], origin.level).toHilbertQuadkey());
+
+        return cells.map((cell) => {
+            return s2.toId(cell);
+        });
+    },
+
     /**
      * Takes a getInventory() response and separates it into pokemon, items, candies, player data,
      * eggs, and pokedex.

--- a/pogobuf/pogobuf.utils.js
+++ b/pogobuf/pogobuf.utils.js
@@ -10,7 +10,7 @@ var s2 = require('s2-geometry').S2;
 
 module.exports = {
     /**
-     * Provides cell IDs of nearby cells based on the given lat lang
+     * Provides cell IDs of nearby cells based on the given coords
      * @param {number} lat
      * @param {number} lng
      * @returns {array}


### PR DESCRIPTION
This updates the example to use the exact perfect shape cell ID's used within the original app.

It returns a perfect shape (s2maps.com, fill in all the ids it returns) of the surrounding area. Matching the one within the app, including the ordering of the app.

It also updates the requirement to `s2-geometry` which is pure JS instead of Native binding. 
