### PR TITLE
Add get_map_objects_min_distance_meters logic

### DIFF
--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -16,6 +16,9 @@ const RequestType = POGOProtos.Networking.Requests.RequestType,
 
 const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
 const DEFAULT_MAP_OBJECTS_DELAY = 5;
+const DEFAULT_MAP_OBJECTS_DISTANCE = 10;
+const DEFAULT_FORT_INTERACTION_RANGE = 40;
+const DEFAULT_FORT_INTERACTION_RANGE_FAR = 1000;
 
 /**
  * Pokémon Go RPC client.
@@ -79,8 +82,7 @@ function Client() {
             .getInventory()
             .checkAwardedBadges()
             .downloadSettings()
-            .batchCall()
-            .then(self.processInitialData);
+            .batchCall();
     };
 
     /**
@@ -142,6 +144,16 @@ function Client() {
      */
     this.setMapObjectsThrottlingEnabled = function(enable) {
         self.mapObjectsThrottlingEnabled = enable;
+    };
+
+    /**
+     * Enables or disables the built-in throttling of interaction calls (forts, encounters)
+     * based on the settings received from the server. Enabled by default, disable if you
+     * want to manage your own throttling.
+     * @param {boolean} enable
+     */
+    this.setInteractionThrottlingEnabled = function(enable) {
+        self.interactionThrottlingEnabled = enable;
     };
 
     /**
@@ -238,6 +250,11 @@ function Client() {
     };
 
     this.fortSearch = function(fortID, fortLatitude, fortLongitude) {
+        // Check interaction range limits
+        if (self.interactionThrottlingEnabled &&
+            !self.withinInteractionRange(fortLatitude, fortLongitude, self.fortInteractionRange)) {
+            return self.batchRequests ? self : false;
+        }
         return self.callOrChain({
             type: RequestType.FORT_SEARCH,
             message: new RequestMessages.FortSearchMessage({
@@ -282,6 +299,11 @@ function Client() {
     };
 
     this.fortDetails = function(fortID, fortLatitude, fortLongitude) {
+        // Check interaction range limits
+        if (self.interactionThrottlingEnabled &&
+            !self.withinInteractionRange(fortLatitude, fortLongitude, self.fortInteractionRangeFar)) {
+            return self.batchRequests ? self : false;
+        }
         return self.callOrChain({
             type: RequestType.FORT_DETAILS,
             message: new RequestMessages.FortDetailsMessage({
@@ -805,6 +827,10 @@ function Client() {
     this.maxTries = 5;
     this.mapObjectsThrottlingEnabled = true;
     this.mapObjectsMinDelay = DEFAULT_MAP_OBJECTS_DELAY * 1000;
+    this.mapObjectsMinDistance = DEFAULT_MAP_OBJECTS_DISTANCE;
+    this.interactionThrottlingEnabled = true;
+    this.fortInteractionRange = DEFAULT_FORT_INTERACTION_RANGE;
+    this.fortInteractionRangeFar = DEFAULT_FORT_INTERACTION_RANGE_FAR;
     this.automaticLongConversionEnabled = true;
 
     /**
@@ -953,23 +979,40 @@ function Client() {
         // If the requests include a map objects request, make sure the minimum delay
         // since the last call has passed
         if (requests.some(r => r.type === RequestType.GET_MAP_OBJECTS)) {
+
+            // Check distance traveled to see if it is past refresh distance
+            var refreshRequired = !self.withinInteractionRange(
+                self.lastMapObjectsLatitude,
+                self.lastMapObjectsLongitude,
+                self.mapObjectsMinDistance);
             var now = new Date().getTime(),
                 delayNeeded = self.lastMapObjectsCall + self.mapObjectsMinDelay - now;
 
-            if (delayNeeded > 0 && self.mapObjectsThrottlingEnabled) {
+            if (delayNeeded > 0 && self.mapObjectsThrottlingEnabled && !refreshRequired) {
                 return Promise.delay(delayNeeded).then(() => self.callRPC(requests, envelope));
             }
 
             self.lastMapObjectsCall = now;
+            self.lastMapObjectsLatitude = self.playerLatitude;
+            self.lastMapObjectsLongitude = self.playerLongitude;
         }
 
-        if (self.maxTries <= 1) return self.tryCallRPC(requests, envelope);
+        var responses;
+        if (self.maxTries <= 1) responses = self.tryCallRPC(requests, envelope);
 
-        return retry(() => self.tryCallRPC(requests, envelope), {
+        responses = retry(() => self.tryCallRPC(requests, envelope), {
             interval: 300,
             backoff: 2,
             max_tries: self.maxTries
         });
+
+        // Check if we need to save settings
+        var downloadSettingsIndex = requests.findIndex(r => r.type === RequestType.DOWNLOAD_SETTINGS);
+        if (downloadSettingsIndex !== -1) {
+            return responses.then(r => this.processDownloadSettings(r, downloadSettingsIndex));
+        }
+
+        return responses;
     };
 
     /**
@@ -1112,22 +1155,48 @@ function Client() {
     };
 
     /**
-     * Processes the data received from the initial API call during init().
+     * Determines the interaction range
+     * @private
+     * @param {number} lat - object's latitude
+     * @param {number} lng - object's longitude
+     * @param {number} cap - max distance
+     * @return {boolean} response - Unomdified responses (to send back to Promise)
+     */
+    this.withinInteractionRange = function(lat, lng, cap) {
+        // Check distance traveled to see if it is past refresh distance
+        var response = true;
+        if (self.playerLatitude && self.playerLongitude && lat && lng && cap) {
+            var distance = Utils.haversineDistance(
+                self.playerLatitude,
+                self.playerLongitude,
+                lat,
+                lng);
+            response = distance < cap;
+        }
+        return response;
+    };
+
+    /**
+     * Processes the data received from any download settings API call.
      * @private
      * @param {Object[]} responses - Respones from API call
+     * @param {integer} index - index of the download settings response
      * @return {Object[]} respones - Unomdified responses (to send back to Promise)
      */
-    this.processInitialData = function(responses) {
-        // Extract the minimum delay of getMapObjects()
-        if (responses.length >= 5) {
-            var settingsResponse = responses[4];
-            if (!settingsResponse.error &&
-                settingsResponse.settings &&
-                settingsResponse.settings.map_settings &&
-                settingsResponse.settings.map_settings.get_map_objects_min_refresh_seconds
-            ) {
+    this.processDownloadSettings = function(responses, index) {
+        // Extract the settings we care about
+        var settingsResponse = responses[index];
+        if (settingsResponse && !settingsResponse.error && settingsResponse.settings) {
+            var settings = settingsResponse.settings;
+            if (settings.map_settings) {
                 self.mapObjectsMinDelay =
-                    settingsResponse.settings.map_settings.get_map_objects_min_refresh_seconds * 1000;
+                    settings.map_settings.get_map_objects_min_refresh_seconds * 1000;
+                self.mapObjectsMinDistance =
+                    settings.map_settings.get_map_objects_min_distance_meters;
+            }
+            if (settings.fort_settings) {
+                self.fortInteractionRange = settings.fort_settings.interaction_range_meters;
+                self.fortInteractionRangeFar = settings.fort_settings.far_interaction_range_meters;
             }
         }
         return responses;

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -14,12 +14,6 @@ const RequestType = POGOProtos.Networking.Requests.RequestType,
     RequestMessages = POGOProtos.Networking.Requests.Messages,
     Responses = POGOProtos.Networking.Responses;
 
-const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
-const DEFAULT_MAP_OBJECTS_DELAY = 30;
-const DEFAULT_MAP_OBJECTS_DISTANCE = 10;
-const DEFAULT_FORT_INTERACTION_RANGE = 40;
-const DEFAULT_FORT_INTERACTION_RANGE_FAR = 1000;
-
 /**
  * Pokémon Go RPC client.
  * @class Client
@@ -823,6 +817,12 @@ function Client() {
         },
         encoding: null
     });
+
+    const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
+    const DEFAULT_MAP_OBJECTS_DELAY = 30;
+    const DEFAULT_MAP_OBJECTS_DISTANCE = 10;
+    const DEFAULT_FORT_INTERACTION_RANGE = 40;
+    const DEFAULT_FORT_INTERACTION_RANGE_FAR = 1000;
 
     this.maxTries = 5;
     this.mapObjectsThrottlingEnabled = true;

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -14,6 +14,8 @@ const RequestType = POGOProtos.Networking.Requests.RequestType,
     RequestMessages = POGOProtos.Networking.Requests.Messages,
     Responses = POGOProtos.Networking.Responses;
 
+const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
+
 /**
  * Pokémon Go RPC client.
  * @class Client
@@ -818,19 +820,13 @@ function Client() {
         encoding: null
     });
 
-    const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
-    const DEFAULT_MAP_OBJECTS_DELAY = 30;
-    const DEFAULT_MAP_OBJECTS_DISTANCE = 10;
-    const DEFAULT_FORT_INTERACTION_RANGE = 40;
-    const DEFAULT_FORT_INTERACTION_RANGE_FAR = 1000;
-
     this.maxTries = 5;
     this.mapObjectsThrottlingEnabled = true;
-    this.mapObjectsMaxDelay = DEFAULT_MAP_OBJECTS_DELAY * 1000;
-    this.mapObjectsMinDistance = DEFAULT_MAP_OBJECTS_DISTANCE;
+    this.mapObjectsMaxDelay = 30 * 1000;
+    this.mapObjectsMinDistance = 10;
     this.interactionThrottlingEnabled = true;
-    this.fortInteractionRange = DEFAULT_FORT_INTERACTION_RANGE;
-    this.fortInteractionRangeFar = DEFAULT_FORT_INTERACTION_RANGE_FAR;
+    this.fortInteractionRange = 40;
+    this.fortInteractionRangeFar = 1000;
     this.automaticLongConversionEnabled = true;
 
     /**

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -15,7 +15,7 @@ const RequestType = POGOProtos.Networking.Requests.RequestType,
     Responses = POGOProtos.Networking.Responses;
 
 const INITIAL_ENDPOINT = 'https://pgorelease.nianticlabs.com/plfe/rpc';
-const DEFAULT_MAP_OBJECTS_DELAY = 5;
+const DEFAULT_MAP_OBJECTS_DELAY = 30;
 const DEFAULT_MAP_OBJECTS_DISTANCE = 10;
 const DEFAULT_FORT_INTERACTION_RANGE = 40;
 const DEFAULT_FORT_INTERACTION_RANGE_FAR = 1000;

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -143,16 +143,6 @@ function Client() {
     };
 
     /**
-     * Enables or disables the built-in throttling of interaction calls (forts, encounters)
-     * based on the settings received from the server. Enabled by default, disable if you
-     * want to manage your own throttling.
-     * @param {boolean} enable
-     */
-    this.setInteractionThrottlingEnabled = function(enable) {
-        self.interactionThrottlingEnabled = enable;
-    };
-
-    /**
      * Sets a callback to be called for any envelope or request just before it is sent to
      * the server (mostly for debugging purposes).
      * @deprecated Use the raw-request event instead
@@ -246,11 +236,6 @@ function Client() {
     };
 
     this.fortSearch = function(fortID, fortLatitude, fortLongitude) {
-        // Check interaction range limits
-        if (self.interactionThrottlingEnabled &&
-            !self.withinInteractionRange(fortLatitude, fortLongitude, self.fortInteractionRange)) {
-            return self.batchRequests ? self : false;
-        }
         return self.callOrChain({
             type: RequestType.FORT_SEARCH,
             message: new RequestMessages.FortSearchMessage({
@@ -295,11 +280,6 @@ function Client() {
     };
 
     this.fortDetails = function(fortID, fortLatitude, fortLongitude) {
-        // Check interaction range limits
-        if (self.interactionThrottlingEnabled &&
-            !self.withinInteractionRange(fortLatitude, fortLongitude, self.fortInteractionRangeFar)) {
-            return self.batchRequests ? self : false;
-        }
         return self.callOrChain({
             type: RequestType.FORT_DETAILS,
             message: new RequestMessages.FortDetailsMessage({
@@ -824,9 +804,6 @@ function Client() {
     this.mapObjectsThrottlingEnabled = true;
     this.mapObjectsMaxDelay = 30 * 1000;
     this.mapObjectsMinDistance = 10;
-    this.interactionThrottlingEnabled = true;
-    this.fortInteractionRange = 40;
-    this.fortInteractionRangeFar = 1000;
     this.automaticLongConversionEnabled = true;
 
     /**
@@ -1189,10 +1166,6 @@ function Client() {
                     settings.map_settings.get_map_objects_max_refresh_seconds * 1000;
                 self.mapObjectsMinDistance =
                     settings.map_settings.get_map_objects_min_distance_meters;
-            }
-            if (settings.fort_settings) {
-                self.fortInteractionRange = settings.fort_settings.interaction_range_meters;
-                self.fortInteractionRangeFar = settings.fort_settings.far_interaction_range_meters;
             }
         }
         return responses;

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -826,7 +826,7 @@ function Client() {
 
     this.maxTries = 5;
     this.mapObjectsThrottlingEnabled = true;
-    this.mapObjectsMinDelay = DEFAULT_MAP_OBJECTS_DELAY * 1000;
+    this.mapObjectsMaxDelay = DEFAULT_MAP_OBJECTS_DELAY * 1000;
     this.mapObjectsMinDistance = DEFAULT_MAP_OBJECTS_DISTANCE;
     this.interactionThrottlingEnabled = true;
     this.fortInteractionRange = DEFAULT_FORT_INTERACTION_RANGE;
@@ -986,7 +986,7 @@ function Client() {
                 self.lastMapObjectsLongitude,
                 self.mapObjectsMinDistance);
             var now = new Date().getTime(),
-                delayNeeded = self.lastMapObjectsCall + self.mapObjectsMinDelay - now;
+                delayNeeded = self.lastMapObjectsCall + self.mapObjectsMaxDelay - now;
 
             if (delayNeeded > 0 && self.mapObjectsThrottlingEnabled && !refreshRequired) {
                 return Promise.delay(delayNeeded).then(() => self.callRPC(requests, envelope));
@@ -1189,8 +1189,8 @@ function Client() {
         if (settingsResponse && !settingsResponse.error && settingsResponse.settings) {
             var settings = settingsResponse.settings;
             if (settings.map_settings) {
-                self.mapObjectsMinDelay =
-                    settings.map_settings.get_map_objects_min_refresh_seconds * 1000;
+                self.mapObjectsMaxDelay =
+                    settings.map_settings.get_map_objects_max_refresh_seconds * 1000;
                 self.mapObjectsMinDistance =
                     settings.map_settings.get_map_objects_min_distance_meters;
             }

--- a/pogobuf/pogobuf.utils.js
+++ b/pogobuf/pogobuf.utils.js
@@ -248,6 +248,30 @@ module.exports = {
     },
 
     /**
+     * Utility method to get the distance in meters between two locations
+     * @param {number} lat1 - origin latitude
+     * @param {number} lng1 - origin longitude
+     * @param {number} lat2 - destination latitude
+     * @param {number} lng2 - destination longitude
+     * @returns {object}
+     * @static
+     */
+    haversineDistance: function(lat1, lng1, lat2, lng2) {
+        var R = 6371000, // radius of earth in meters
+            lat1Radians = lat1 * Math.PI / 180,
+            lat2Radians = lat2 * Math.PI / 180,
+            latDelta = (lat2 - lat1) * Math.PI / 180,
+            lngDelta = (lng2 - lng1) * Math.PI / 180;
+
+        var a = Math.sin(latDelta / 2) * Math.sin(latDelta / 2) +
+                Math.cos(lat1Radians) * Math.cos(lat2Radians) *
+                Math.sin(lngDelta / 2) * Math.sin(lngDelta / 2);
+        var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c;
+    },
+
+    /**
      * Utility method to convert all Long.js objects to integers or strings
      * @param {object} object – An object
      * @returns {object}

--- a/pogobuf/pogobuf.utils.js
+++ b/pogobuf/pogobuf.utils.js
@@ -249,10 +249,10 @@ module.exports = {
 
     /**
      * Utility method to get the distance in meters between two locations
-     * @param {number} lat1 - origin latitude
-     * @param {number} lng1 - origin longitude
-     * @param {number} lat2 - destination latitude
-     * @param {number} lng2 - destination longitude
+     * @param {number} lat1 - first latitude
+     * @param {number} lng1 - first longitude
+     * @param {number} lat2 - second latitude
+     * @param {number} lng2 - second longitude
      * @returns {object}
      * @static
      */


### PR DESCRIPTION
Implement map objects and interaction distance restrictions via the haversine formula.  Also updated the download settings to be saved on every API call in order to update the restrictions.

The haversine formula is in Utils so it can be used to implement the encounter restrictions also found in the download settings response.  Since the pokemon lat,lng isn't passed into the client, however, that restriction will need to be implemented by the consumer.
