### PR TITLE
Added cell level passing into getCellIDs Util function

### DIFF
--- a/examples/list-catchable-pokemon.js
+++ b/examples/list-catchable-pokemon.js
@@ -26,7 +26,7 @@ google.login(username, password).then(token => {
 }).then(() => {
     console.log('Authenticated, waiting for first map refresh (30s)');
     setInterval(() => {
-        var cellIDs = pogobuf.Utils.getCellIDs(lat, lng);
+        var cellIDs = pogobuf.Utils.getCellIDs(lat, lng, 5, 17);
         return bluebird.resolve(client.getMapObjects(cellIDs, Array(cellIDs.length).fill(0))).then(mapObjects => {
             return mapObjects.map_cells;
         }).each(cell => {

--- a/pogobuf.d.ts
+++ b/pogobuf.d.ts
@@ -435,7 +435,7 @@ declare namespace pogobuf {
          * @param {number} longitude Longitude
          * @param {number} radius Radius of the square in cells (optional) (default value is 3)
          */
-        function getCellIDs(latitude: number, longitude: number, radius?: number): string[];
+        function getCellIDs(latitude: number, longitude: number, radius?: number, level?: number): string[];
 
         /**
          * Takes a getInventory() response and separates it into pokemon, items, candies, player data, eggs, and pokedex.

--- a/pogobuf/pogobuf.utils.js
+++ b/pogobuf/pogobuf.utils.js
@@ -15,17 +15,19 @@ module.exports = {
      * @param {number} lat
      * @param {number} lng
      * @param {number} [radius=3]
+     * @param {number} [level=15]
      * @returns {array}
      * @static
      */
-    getCellIDs: function(lat, lng, radius) {
+    getCellIDs: function(lat, lng, radius, level) {
         if (typeof radius === 'undefined') radius = 3;
+        if (typeof level === 'undefined') level = 15;
 
         /* eslint-disable new-cap */
         var origin = s2.S2Cell.FromLatLng({
             lat: lat,
             lng: lng
-        }, 15);
+        }, level);
         var cells = [];
 
         cells.push(origin.toHilbertQuadkey()); // middle block


### PR DESCRIPTION
The library’s util has a function which lets api users get the cell ids in a specific region. 

After a trial and test, I found out that although cell level 15 is used to getMapObjects, any cell level can be used.

By increasing the cell level, more data can be retrieved, and potentially decrease api calls due to scanning all level 15 cells.