### PR TITLE
Allow clients to set altitude (ready)

### DIFF
--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -46,7 +46,7 @@ function Client() {
      * Note that this does not actually update the player location on the server, it only sets
      * the location to be used in following API calls. To update the location on the server you
      * probably want to call {@link #updatePlayer}.
-     * @param {number} latitude - The player's latitude
+     * @param {number|object} latitude - The player's latitude, or an object containing all four parameters
      * @param {number} longitude - The player's longitude
      * @param {number} [accuracy=0] - The location accuracy in m
      * @param {number} [altitude=0] - The player's altitude

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -46,7 +46,7 @@ function Client() {
      * Note that this does not actually update the player location on the server, it only sets
      * the location to be used in following API calls. To update the location on the server you
      * probably want to call {@link #updatePlayer}.
-     * @param {number|object} latitude - The player's latitude, or an object containing all four parameters
+     * @param {number|object} latitude - The player's latitude, or an object with parameters
      * @param {number} longitude - The player's longitude
      * @param {number} [accuracy=0] - The location accuracy in m
      * @param {number} [altitude=0] - The player's altitude

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -52,8 +52,8 @@ function Client() {
      * @param {number} [altitude=0] - The player's altitude
      */
     this.setPosition = function(latitude, longitude, accuracy, altitude) {
-        if (typeof latitude == "object") {
-            let pos = latitude;
+        if (typeof latitude === 'object') {
+            const pos = latitude;
             latitude = pos.latitude;
             longitude = pos.longitude;
             accuracy = pos.accuracy;

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -49,11 +49,20 @@ function Client() {
      * @param {number} latitude - The player's latitude
      * @param {number} longitude - The player's longitude
      * @param {number} [accuracy=0] - The location accuracy in m
+     * @param {number} [altitude=0] - The player's altitude
      */
-    this.setPosition = function(latitude, longitude, accuracy) {
+    this.setPosition = function(latitude, longitude, accuracy, altitude) {
+        if (typeof latitude == "object") {
+            let pos = latitude;
+            latitude = pos.latitude;
+            longitude = pos.longitude;
+            accuracy = pos.accuracy;
+            altitude = pos.altitude;
+        }
         self.playerLatitude = latitude;
         self.playerLongitude = longitude;
         self.playerLocationAccuracy = accuracy || 0;
+        self.playerAltitude = altitude || 0;
     };
 
     /**


### PR DESCRIPTION
Warning: Altitude is not actually used by default by the api, it can be used when building the signature with `client.setSignatureInfo()`