### PR TITLE
Compatibility with PokeFarmer Hash Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "bluebird-retry": "^0.8.0",
+    "bluebird": "^3.4.7",
+    "bluebird-retry": "^0.10.1",
     "gpsoauthnode": "0.0.5",
     "long": "^3.2.0",
     "node-pogo-protos": "^2.4.0",
-    "node-pogo-signature": "^3.0.0",
+    "node-pogo-signature": "^4.0.0",
     "request": "^2.79.0",
     "s2-geometry": "^1.2.9"
   },
   "devDependencies": {
-    "eslint": "^3.1.1",
-    "eslint-config-airbnb-base": "^10.0.1",
+    "eslint": "^3.12.2",
+    "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0"
   }
 }

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -149,7 +149,7 @@ function Client() {
             return Promise.resolve();
         } else {
             // correct version is verified against available versions on the server
-            return request.getAsync('http://hashing.pogodev.io/api/hash/versions')
+            return request.getAsync(this.hashServerHost + 'api/hash/versions')
                 .then(response => {
                     const iosVersion = '1.' + (+this.version - 3000) / 100;
                     const versions = JSON.parse(response.body);

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -22,12 +22,11 @@ const DEFAULT_MAP_OBJECTS_DELAY = 5;
  * @memberof pogobuf
  * @param {object} options - client options
  */
-function Client(options) {
+function Client() {
     if (!(this instanceof Client)) {
-        return new Client(options);
+        return new Client();
     }
     const self = this;
-    self.options = options;
 
     /**
      * PUBLIC METHODS
@@ -125,6 +124,15 @@ function Client(options) {
 
         self.batchClear();
         return p;
+    };
+
+    /**
+     * If true, response objects will contain a pogoBufRequest field with the id of the
+     * associated request. Allows you to detect response when using batch mode.
+     * @param {bool} includeReqTypeInResponse - if true, include request id in response objects
+     */
+    this.setIncludeReqTypeInResponse = function(includeReqTypeInResponse) {
+        self.includeReqTypeInResponse = includeReqTypeInResponse;
     };
 
     /**
@@ -1164,7 +1172,7 @@ function Client(options) {
                                 return;
                             }
 
-                            if (options.includeReqTypeInResponse) {
+                            if (self.includeReqTypeInResponse) {
                                 responseMessage.pogoBufRequest = requests[i].type;
                             }
                             responses.push(responseMessage);

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -20,7 +20,6 @@ const DEFAULT_MAP_OBJECTS_DELAY = 5;
  * Pokémon Go RPC client.
  * @class Client
  * @memberof pogobuf
- * @param {object} options - client options
  */
 function Client() {
     if (!(this instanceof Client)) {

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -20,12 +20,14 @@ const DEFAULT_MAP_OBJECTS_DELAY = 5;
  * Pokémon Go RPC client.
  * @class Client
  * @memberof pogobuf
+ * @param {object} options - client options
  */
-function Client() {
+function Client(options) {
     if (!(this instanceof Client)) {
-        return new Client();
+        return new Client(options);
     }
     const self = this;
+    self.options = options;
 
     /**
      * PUBLIC METHODS
@@ -1162,6 +1164,9 @@ function Client() {
                                 return;
                             }
 
+                            if (options.includeReqTypeInResponse) {
+                                responseMessage.pogoBufRequest = requests[i].type;
+                            }
                             responses.push(responseMessage);
                         }
                     }

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -145,10 +145,10 @@ function Client() {
     /**
      * If true, response objects will contain a pogoBufRequest field with the id of the
      * associated request. Allows you to detect response when using batch mode.
-     * @param {bool} includeReqTypeInResponse - if true, include request id in response objects
+     * @param {bool} includeRequestTypeInResponse - if true, include request id in response objects
      */
-    this.setIncludeReqTypeInResponse = function(includeReqTypeInResponse) {
-        self.includeReqTypeInResponse = includeReqTypeInResponse;
+    this.setIncludeRequestTypeInResponse = function(includeRequestTypeInResponse) {
+        self.includeRequestTypeInResponse = includeRequestTypeInResponse;
     };
 
     /**
@@ -1195,7 +1195,7 @@ function Client() {
                                 return;
                             }
 
-                            if (self.includeReqTypeInResponse) {
+                            if (self.includeRequestTypeInResponse) {
                                 responseMessage.pogoBufRequest = requests[i].type;
                             }
                             responses.push(responseMessage);

--- a/pogobuf/pogobuf.client.js
+++ b/pogobuf/pogobuf.client.js
@@ -73,7 +73,6 @@ function Client() {
     this.init = function(downloadSettings) {
         if (typeof downloadSettings === 'undefined') downloadSettings = true;
 
-        self.signatureBuilder = new pogoSignature.Builder({ protos: POGOProtos });
         self.lastMapObjectsCall = 0;
 
         /*
@@ -123,6 +122,24 @@ function Client() {
 
         self.batchClear();
         return p;
+    };
+
+    /**
+     * Set API version. 4500 means local hashing, upper version only
+     * works with hashing server.
+     * @param {string} version - api version (4500 or 5100)
+     */
+    this.setVersion = function(version) {
+        this.version = version;
+    };
+
+    /**
+     * Use hash server
+     * @param {string} key - key purchased from Pokefarmer guys
+     */
+    this.activateHashServer = function(key) {
+        this.useHashSever = true;
+        this.hashKey = key;
     };
 
     /**
@@ -988,6 +1005,13 @@ function Client() {
                 return;
             }
 
+            self.signatureBuilder = new pogoSignature.Builder({ protos: POGOProtos });
+            this.version = this.version || '4500';
+            self.signatureBuilder.version = '0.' + ((+this.version) / 100).toFixed(0);
+            if (this.useHashSever) {
+                const hashVersion = '1' + Math.floor((+this.version - 3000) / 100);
+                self.signatureBuilder.useHashingServer('hashing.pogodev.io', 80, this.hashKey, '1' + hashVersion);
+            }
             self.signatureBuilder.setAuthTicket(envelope.auth_ticket);
             self.signatureBuilder.setLocation(envelope.latitude, envelope.longitude, envelope.accuracy);
             if (typeof self.signatureInfo === 'function') {


### PR DESCRIPTION
Change for existing apps should be minimal:
`client.setVersion('5100')`  - Same version user should send to downloadRemoteConfig() or getAstDigest() so we don't introduce a new version format
`clint.activateHashServer('key')`